### PR TITLE
Feature sonarqube

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ node("${BUILD_NODE}") {
         checkout(scm)
     }
 
-    stage("Load Variables") { // This is needed for DOCKER_REGISTRY_URL, OSSIM_MAVEN_PROXY, and OMAR_MAVEN_PROXY
+    stage("Load Variables") { // This is needed for Docker, Maven, and Sonarqube variables
         step([$class     : "CopyArtifact",
               projectName: "ossim-ci",
               filter     : "common-variables.groovy",
@@ -50,6 +50,15 @@ node("${BUILD_NODE}") {
             docker push $DOCKER_REGISTRY_URL/omar-volume-cleanup
             """
         }
+    }
+
+    stage("Code Scans") {
+        withSonarQubeEnv(SONARQUBE_NAME)
+        sh """
+        gradle sonarqube \
+            -Dsonar.projectKey=ossimlabs_omar-volume-cleanup \
+            -Dsonar.organization=ossimlabs \
+        """
     }
 
     stage("Clean Workspace") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,8 @@ node("${BUILD_NODE}") {
     }
 
     stage("Publish Jar") {
-        withCredentials([[$class: 'UsernamePasswordMultiBinding',
-                          credentialsId: 'nexusCredentials',
+        withCredentials([[$class          : 'UsernamePasswordMultiBinding',
+                          credentialsId   : 'nexusCredentials',
                           usernameVariable: 'ORG_GRADLE_PROJECT_uploadMavenRepoUsername',
                           passwordVariable: 'ORG_GRADLE_PROJECT_uploadMavenRepoPassword']]) {
             sh """
@@ -53,12 +53,13 @@ node("${BUILD_NODE}") {
     }
 
     stage("Code Scans") {
-        withSonarQubeEnv(SONARQUBE_NAME)
-        sh """
-        gradle sonarqube \
-            -Dsonar.projectKey=ossimlabs_omar-volume-cleanup \
-            -Dsonar.organization=ossimlabs \
-        """
+        withSonarQubeEnv(SONARQUBE_NAME) {
+            sh """
+            gradle sonarqube \
+                -Dsonar.projectKey=ossimlabs_omar-volume-cleanup \
+                -Dsonar.organization=ossimlabs \
+            """
+        }
     }
 
     stage("Clean Workspace") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node("${BUILD_NODE}") {
 
     stage("Publish Jar") {
         withCredentials([[$class          : 'UsernamePasswordMultiBinding',
-                          credentialsId   : 'nexusCredentials',
+                          credentialsId   : 'mavenCredentials',
                           usernameVariable: 'ORG_GRADLE_PROJECT_uploadMavenRepoUsername',
                           passwordVariable: 'ORG_GRADLE_PROJECT_uploadMavenRepoPassword']]) {
             sh """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,8 @@ node("${BUILD_NODE}") {
     }
 
     stage("Publish Jar") {
-        withCredentials([[$class          : 'UsernamePasswordMultiBinding',
-                          credentialsId   : 'mavenCredentials',
+        withCredentials([[$class: 'UsernamePasswordMultiBinding',
+                          credentialsId: 'mavenCredentials',
                           usernameVariable: 'ORG_GRADLE_PROJECT_uploadMavenRepoUsername',
                           passwordVariable: 'ORG_GRADLE_PROJECT_uploadMavenRepoPassword']]) {
             sh """
@@ -52,7 +52,7 @@ node("${BUILD_NODE}") {
         }
     }
 
-    stage("Code Scans") {
+    stage("Scan Code") {
         sh """
         gradle sonarqube \
             -Dsonar.projectKey=ossimlabs_omar-volume-cleanup \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,13 +53,13 @@ node("${BUILD_NODE}") {
     }
 
     stage("Code Scans") {
-        withSonarQubeEnv(SONARQUBE_NAME) {
-            sh """
-            gradle sonarqube \
-                -Dsonar.projectKey=ossimlabs_omar-volume-cleanup \
-                -Dsonar.organization=ossimlabs \
-            """
-        }
+        sh """
+        gradle sonarqube \
+            -Dsonar.projectKey=ossimlabs_omar-volume-cleanup \
+            -Dsonar.organization=$SONARQUBE_ORGANIZATION \
+            -Dsonar.host.url=$SONARQUBE_HOST \
+            -Dsonar.login=$SONARQUBE_TOKEN
+        """
     }
 
     stage("Clean Workspace") {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build Status](https://jenkins.ossim.io/buildStatus/icon?job=omar-volume-cleanup/master)](https://jenkins.ossim.io/job/omar-volume-cleanup/master)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ossimlabs_omar-volume-cleanup&metric=alert_status)](https://sonarcloud.io/dashboard?id=ossimlabs_omar-volume-cleanup)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ossimlabs_omar-volume-cleanup&metric=coverage)](https://sonarcloud.io/dashboard?id=ossimlabs_omar-volume-cleanup)
 
 # Quickstart
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "1.3.20"
-    id("com.google.cloud.tools.jib") version "1.0.0"
     `maven-publish`
+    id("com.google.cloud.tools.jib") version "1.0.0"
+    id("org.sonarqube") version "2.7"
 }
 
 group = "io.ossim.omar.apps"


### PR DESCRIPTION
Branch build status: [![Build Status](https://jenkins.ossim.io/buildStatus/icon?job=omar-volume-cleanup/feature-sonarcloud)](https://jenkins.ossim.io/job/omar-volume-cleanup/job/feature-sonarcloud/)

Added sonarqube to the build process.
Currently, the code scan stage does fail the pipeline, but only after pushing the Jar and Dockerfile. We may want to change that in the future if we enforce a certain quality level.

Code scans are not run from `gradle build`.

Highside does have a SonarQube available. When we move highside, it's expected that we will use the highside common-variables which includes:
SONARQUBE_HOST
SONARQUBE_ORGANIZATION
SONARQUBE_TOKEN